### PR TITLE
Fixes GET request not reloading meals and recipes when coming back to website.

### DIFF
--- a/Back-end/server/index.js
+++ b/Back-end/server/index.js
@@ -700,7 +700,7 @@ server.get("/nutrients/:ingredientID", (req, res) => {
     .first()
     .then(ingredients => {
       db("nutrients")
-        .where({ ingredient_id: ingredientId })
+        .where({ ingredients_id: ingredientId })
         .then(nutrients => {
           //Returns all the nutrients
           res.status(200).json(nutrients);

--- a/Front-end/mealhelper/src/components/Meals/Meals.js
+++ b/Front-end/mealhelper/src/components/Meals/Meals.js
@@ -45,7 +45,7 @@ class Meals extends Component {
   ///converted to Imperial measurement
   componentDidMount(props) {
     if (localStorage.getItem("token")) {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
       axios
         .get(`https://labs8-meal-helper.herokuapp.com/recipe/user/${id}`)
         .then(recipess => {
@@ -63,7 +63,7 @@ class Meals extends Component {
   }
 
   componentGetMeals() {
-    const id = this.props.user.userID;
+    const id = localStorage.getItem("user_id");
     axios
       .get(`https://labs8-meal-helper.herokuapp.com/users/${id}/meals`)
       .then(meals => {
@@ -102,7 +102,8 @@ class Meals extends Component {
   }
   saveMeal = event => {
     event.preventDefault();
-    const user_id = this.props.user.userID;
+
+    const user_id = localStorage.getItem("user_id");
     const recipe_id = this.state.recipe.id;
     const {
       mealTime,
@@ -149,6 +150,7 @@ class Meals extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
   getWeatherZip = event => {

--- a/Front-end/mealhelper/src/components/Settings/EditEmail.js
+++ b/Front-end/mealhelper/src/components/Settings/EditEmail.js
@@ -45,7 +45,7 @@ class EditEmail extends Component {
   }
 
   componentDidMount = () => {
-    const id = this.props.user.userID;
+    const id = localStorage.getItem("user_id");
     axios
       .get(`https://labs8-meal-helper.herokuapp.com/users/${id}`)
       .then(user => {
@@ -81,7 +81,7 @@ class EditEmail extends Component {
       this.setState({ visable: true });
       setTimeout(this.toggleVisability, 3000);
     } else {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
       const { email, password } = this.state;
       const user = { email, password };
       axios
@@ -103,6 +103,7 @@ class EditEmail extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
 

--- a/Front-end/mealhelper/src/components/Settings/EditPassword.js
+++ b/Front-end/mealhelper/src/components/Settings/EditPassword.js
@@ -45,7 +45,7 @@ class EditPassword extends Component {
   }
 
   componentDidMount = () => {
-    const id = this.props.user.userID;
+    const id = localStorage.getItem("user_id");
     axios
       .get(`https://labs8-meal-helper.herokuapp.com/users/${id}`)
       .then(user => {
@@ -90,7 +90,7 @@ class EditPassword extends Component {
       this.setState({ visablePassword: true });
       setTimeout(this.toggleVisability, 3000);
     } else {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
       const { oldpassword, newpassword } = this.state;
       const user = { oldpassword, newpassword };
       axios
@@ -115,6 +115,7 @@ class EditPassword extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
 

--- a/Front-end/mealhelper/src/components/Settings/EditZip.js
+++ b/Front-end/mealhelper/src/components/Settings/EditZip.js
@@ -44,7 +44,7 @@ class EditZip extends Component {
   }
 
   componentDidMount = () => {
-    const id = this.props.user.userID;
+    const id = localStorage.getItem("user_id");
     axios
       .get(`https://labs8-meal-helper.herokuapp.com/users/${id}`)
       .then(user => {
@@ -80,7 +80,7 @@ class EditZip extends Component {
       this.setState({ visable: true });
       setTimeout(this.toggleVisability, 3000);
     } else {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
       const { zip, password } = this.state;
       const user = { zip, password };
       axios
@@ -105,6 +105,7 @@ class EditZip extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
 

--- a/Front-end/mealhelper/src/components/Settings/SettingsMain.js
+++ b/Front-end/mealhelper/src/components/Settings/SettingsMain.js
@@ -44,7 +44,7 @@ class SettingsMain extends Component {
 
   componentDidMount = () => {
     if (localStorage.getItem("token")) {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
       axios
         .get(`https://labs8-meal-helper.herokuapp.com/users/${id}`)
         .then(user => {
@@ -85,6 +85,7 @@ class SettingsMain extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
 

--- a/Front-end/mealhelper/src/components/billing/billing.js
+++ b/Front-end/mealhelper/src/components/billing/billing.js
@@ -70,6 +70,7 @@ class Billing extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
 

--- a/Front-end/mealhelper/src/components/creatnewrecipe/createnewrecipe.js
+++ b/Front-end/mealhelper/src/components/creatnewrecipe/createnewrecipe.js
@@ -46,7 +46,7 @@ class CreateNewRecipe extends Component {
   };
   componentDidMount() {
     if (localStorage.getItem("token")) {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
       this.props.getRecipe(id);
     } else {
       this.props.history.push("/");
@@ -115,6 +115,7 @@ class CreateNewRecipe extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
   render() {

--- a/Front-end/mealhelper/src/components/display/display.js
+++ b/Front-end/mealhelper/src/components/display/display.js
@@ -48,7 +48,7 @@ class Display extends Component {
 
   componentDidMount = () => {
     if (localStorage.getItem("token")) {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
       axios
         .get(`https://labs8-meal-helper.herokuapp.com/recipe/user/${id}`)
         .then(recipess => {
@@ -65,7 +65,7 @@ class Display extends Component {
 
   componentGetMeals() {
     console.log(this.state.recipes);
-    const id = this.props.user.userID;
+    const id = localStorage.getItem("user_id");
     axios
       .get(`https://labs8-meal-helper.herokuapp.com/users/${id}/meals`)
       .then(meals => {

--- a/Front-end/mealhelper/src/components/homepage/homepage.js
+++ b/Front-end/mealhelper/src/components/homepage/homepage.js
@@ -49,7 +49,8 @@ class HomePage extends Component {
 
   componentDidMount = () => {
     if (localStorage.getItem("token")) {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
+      console.log(id);
       axios
         .get(`https://labs8-meal-helper.herokuapp.com/recipe/user/${id}`)
         .then(recipess => {
@@ -65,8 +66,8 @@ class HomePage extends Component {
   };
 
   componentGetMeals() {
-    console.log(this.state.recipes);
-    const id = this.props.user.userID;
+    const id = localStorage.getItem("user_id");
+    console.log(id);
     axios
       .get(`https://labs8-meal-helper.herokuapp.com/users/${id}/meals`)
       .then(meals => {
@@ -106,6 +107,7 @@ class HomePage extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
 

--- a/Front-end/mealhelper/src/components/recipes/Nutrients.js
+++ b/Front-end/mealhelper/src/components/recipes/Nutrients.js
@@ -55,7 +55,7 @@ class Nutrients extends Component {
     const { name, calories, servings } = this.props;
     const recipe = { name, calories, servings };
     const data = await this.props.addRecipe(recipe, this.props.user.userID);
-    console.log(data);
+
     // console.log("this is the count of ingredients array", countIngredients);
     this.saveRecipeIngredients();
   }
@@ -63,26 +63,27 @@ class Nutrients extends Component {
   async saveRecipeIngredients(props) {
     let countIngredients = this.state.selectedFoods.length;
     let recipe_ids = this.props.recipes.pop();
-    console.log(recipe_ids);
+    const id = localStorage.getItem("user_id");
+
     const data = await this.props.addMultipleIngredients(
       this.state.selectedFoods,
-      this.props.user.userID,
+      id,
       countIngredients,
       recipe_ids.id
     );
-    console.log(data);
 
     this.saveRecipeNutrition();
   }
 
   saveRecipeNutrition = () => {
+    const id = localStorage.getItem("user_id");
     const nutrients = this.state.nutrients.map(nutrient => {
       return nutrient.nutrients;
     });
     let countNutrients = nutrients.length;
     this.props.addMultipleNutrients(
       nutrients,
-      this.props.user.userID,
+      id,
       countNutrients,
       this.props.ingredients
     );
@@ -91,25 +92,21 @@ class Nutrients extends Component {
     const filteredFoods = this.state.nutrients.filter(
       (item, idx) => itemIndex !== idx
     );
-    console.log(filteredFoods);
+
     this.setState({ nutrients: filteredFoods });
   };
 
   sumKCAL = (foods, prop) => {
-    console.log(prop);
-
     return foods
       .reduce((memo, food) => parseInt(food.nutrients[0].value, 10) + memo, 0.0)
       .toFixed(0);
   };
   sumProtein = (foods, prop) => {
-    console.log(prop);
     return foods
       .reduce((memo, food) => parseFloat(food.nutrients[1].value) + memo, 0.0)
       .toFixed(2);
   };
   sumFat = (foods, prop) => {
-    console.log(prop);
     return foods
       .reduce(
         (memo, food) => parseFloat(food.nutrients[2].value, 10) + memo,
@@ -118,7 +115,6 @@ class Nutrients extends Component {
       .toFixed(2);
   };
   sumCarb = (foods, prop) => {
-    console.log(prop);
     return foods
       .reduce(
         (memo, food) => parseFloat(food.nutrients[3].value, 10) + memo,

--- a/Front-end/mealhelper/src/components/sidebar/sidebar.js
+++ b/Front-end/mealhelper/src/components/sidebar/sidebar.js
@@ -47,7 +47,7 @@ class SideBar extends Component {
 
   componentDidMount = () => {
     if (localStorage.getItem("token")) {
-      const id = this.props.user.userID;
+      const id = localStorage.getItem("user_id");
       axios
         .get(`https://labs8-meal-helper.herokuapp.com/recipe/user/${id}`)
         .then(recipess => {
@@ -64,7 +64,7 @@ class SideBar extends Component {
 
   componentGetMeals() {
     console.log(this.state.recipes);
-    const id = this.props.user.userID;
+    const id = localStorage.getItem("user_id");
     axios
       .get(`https://labs8-meal-helper.herokuapp.com/users/${id}/meals`)
       .then(meals => {
@@ -104,6 +104,7 @@ class SideBar extends Component {
   logout = event => {
     event.preventDefault();
     localStorage.removeItem("token");
+    localStorage.removeItem("user_id");
     this.props.history.push("/");
   };
 

--- a/Front-end/mealhelper/src/store/reducers/userReducer.js
+++ b/Front-end/mealhelper/src/store/reducers/userReducer.js
@@ -35,7 +35,9 @@ export const userReducer = (state = initialState, action) => {
       return { ...state, addingUser: true };
     case ADDED_USER:
       //Returns the user ID and the JWT token and sets it as JSON to user
+      console.log(action.payload);
       localStorage.setItem("token", action.payload.token);
+      localStorage.setItem("user_id", action.payload.userID);
       return { ...state, addingUser: false, user: action.payload };
     case ADDING_USER_ERROR:
       //Shoots off if there is an error creating a new user
@@ -52,6 +54,7 @@ export const userReducer = (state = initialState, action) => {
     case GOT_USER:
       //Returns the user ID and the JWT token and sets it as JSON to user
       localStorage.setItem("token", action.payload.token);
+      localStorage.setItem("user_id", action.payload.userID);
       return { ...state, gettingUser: false, user: action.payload };
     case GETTING_USERS_ERROR:
       //Shoots off if there is an error logging in a user


### PR DESCRIPTION
# Description

Fixes GET request not reloading meals and recipes when coming back to website.
Initally loaded user_id from props, but quickly realized that if a user came back to the website while still being logged in, props would be empty then.


## Type of change

Please delete options that are not relevant.

- [x] Bug Fix

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Tested using local host deploy

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflict